### PR TITLE
Add multipage router to shiny app

### DIFF
--- a/rshiny_app/README.md
+++ b/rshiny_app/README.md
@@ -1,11 +1,11 @@
 # R Shiny Example App
 
-This repository now contains a minimal Shiny application. Run the app using `shiny::runApp('rshiny_app')` in R.
-
-The datasets are loaded from `rshiny_app/data/PUDC_SUIVI TRIMESTRE  DU PTBA 2025 VF.xlsx`.
-
-The home page uses the **slickR** package to display an image carousel. The app now detects if this package is missing and falls back to static images. For the full carousel experience install slickR with:
+Run the application in R with:
 
 ```R
-install.packages("slickR")
+shiny::runApp('rshiny_app')
 ```
+
+The app now uses **shiny.router** to provide a modern multi-page navigation bar. Pages are accessible via links like `#/accueil` or `#/financier` without reloading the whole interface.
+
+Datasets are loaded from `rshiny_app/data/Base0.xlsx`. The home page displays an image carousel powered by the **slickR** package when available; otherwise static images are shown.

--- a/rshiny_app/app.R
+++ b/rshiny_app/app.R
@@ -5,9 +5,85 @@ library(leaflet)
 library(readxl)
 library(dplyr)
 library(plotly)
-library(slickR)
+library(shiny.router)
+# slickR is optional
 
-# UI personnalisé avec menu horizontal et logo intégré
+#---- UI pages ----
+accueil_page <- function() {
+  div(
+    br(),
+    column(12, align = "center",
+           tags$img(src = "pudc_logo.png", height = "100px"),
+           br(),
+           div(style = "background-color: #558C7C; color: white; padding: 20px;",
+               tags$h1("Tableau de bord de suivi", style = "font-weight:bold; font-size: 36px; margin:0;"),
+               tags$h2("PTBA DU PUDC 2025", style = "margin:0;")
+           ),
+           br(),
+           tags$img(src = "arbre.png", height = "180px"),
+           br(),
+           div(style = "border: 1px solid #003366; background-color: #f0f8ff; display: flex; align-items: center; justify-content: space-between; padding: 10px 20px; margin-bottom: 20px;",
+               tags$h3("Nos Réalisations", style = "color: #003366; font-weight: bold; margin: 0;"),
+               div(
+                 tags$img(src = "miniature1.png", height = "30px", style = "margin-left: 10px;"),
+                 tags$img(src = "miniature2.png", height = "30px", style = "margin-left: 10px;"),
+                 tags$img(src = "miniature3.png", height = "30px", style = "margin-left: 10px;")
+               )
+           ),
+           br(), br(),
+           uiOutput("carousel"),
+           br(),
+           fluidRow(
+             column(2, tags$img(src = "miniature1.png", width = "100%")),
+             column(2, tags$img(src = "miniature2.png", width = "100%")),
+             column(2, tags$img(src = "miniature3.png", width = "100%")),
+             column(2, tags$img(src = "miniature4.png", width = "100%")),
+             column(2, tags$img(src = "miniature5.png", width = "100%")),
+             column(2, tags$img(src = "miniature6.png", width = "100%"))
+           ),
+           br(),
+           div(style = "background-color: #003366; color: white; padding: 20px; font-size: 14px;",
+               "Programme d'Urgence de Développement Communautaire | Contact | Mentions légales",
+               tags$br(),
+               "Ministère du Développement communautaire, de la Solidarité nationale et de l'Équité territoriale"
+           )
+    )
+  )
+}
+
+financier_page <- function() {
+  div(
+    h2("Suivi Financier"),
+    plotOutput("budgetPlot"),
+    tableOutput("budgetTable")
+  )
+}
+
+indicateurs_page <- function() {
+  div(
+    h2("Indicateurs"),
+    plotOutput("composantePlot")
+  )
+}
+
+resume_page <- function() {
+  div(h2("Page en construction"))
+}
+
+assistant_page <- function() {
+  div(h2("Page en construction"))
+}
+
+#---- Router definition ----
+router <- make_router(
+  route("accueil", accueil_page()),
+  route("financier", financier_page()),
+  route("indicateurs", indicateurs_page()),
+  route("resume", resume_page()),
+  route("assistant", assistant_page())
+)
+
+#---- Main UI ----
 ui <- fluidPage(
   tags$head(
     tags$style(HTML("
@@ -34,69 +110,61 @@ ui <- fluidPage(
   div(class = "navbar-custom",
       div(class = "navbar-logo", tags$img(src = "logo.png")),
       div(class = "navbar-menu",
-          tags$a(href = "#accueil", "Home"),
-          tags$a(href = "#technique", "Suivi Technique"),
-          tags$a(href = "#financier", "Suivi financier"),
-          tags$a(href = "#indicateurs", "Réalisation globale"),
-          tags$a(href = "#realisations", "Indicateurs"),
-          tags$a(href = "#resume", "Résumé"),
-          tags$a(href = "#assistant", "Assistant")
+          tags$a(href = route_link("accueil"), "Accueil"),
+          tags$a(href = route_link("financier"), "Suivi Financier"),
+          tags$a(href = route_link("indicateurs"), "Indicateurs"),
+          tags$a(href = route_link("resume"), "Résumé"),
+          tags$a(href = route_link("assistant"), "Assistant")
       )
   ),
-  div(id = "accueil",
-      br(),
-      column(12, align = "center",
-             tags$img(src = "pudc_logo.png", height = "100px"),
-             br(),
-             div(style = "background-color: #558C7C; color: white; padding: 20px;",
-                 tags$h1("Tableau de bord de suivi", style = "font-weight:bold; font-size: 36px; margin:0;"),
-                 tags$h2("PTBA DU PUDC 2025", style = "margin:0;")
-             ),
-             br(),
-             tags$img(src = "arbre.png", height = "180px"),
-             br(),
-             div(style = "border: 1px solid #003366; background-color: #f0f8ff; display: flex; align-items: center; justify-content: space-between; padding: 10px 20px; margin-bottom: 20px;",
-                 tags$h3("Nos Réalisations", style = "color: #003366; font-weight: bold; margin: 0;"),
-                 div(
-                   tags$img(src = "miniature1.png", height = "30px", style = "margin-left: 10px;"),
-                   tags$img(src = "miniature2.png", height = "30px", style = "margin-left: 10px;"),
-                   tags$img(src = "miniature3.png", height = "30px", style = "margin-left: 10px;")
-                 )
-             ),
-             br(), br(),
-             slickROutput("carousel", width = "80%", height = "400px"),
-             br(),
-             fluidRow(
-               column(2, tags$img(src = "miniature1.png", width = "100%")),
-               column(2, tags$img(src = "miniature2.png", width = "100%")),
-               column(2, tags$img(src = "miniature3.png", width = "100%")),
-               column(2, tags$img(src = "miniature4.png", width = "100%")),
-               column(2, tags$img(src = "miniature5.png", width = "100%")),
-               column(2, tags$img(src = "miniature6.png", width = "100%"))
-             ),
-             br(),
-             div(style = "background-color: #003366; color: white; padding: 20px; font-size: 14px;",
-                 "Programme d'Urgence de Développement Communautaire | Contact | Mentions légales",
-                 tags$br(),
-                 "Ministère du Développement communautaire, de la Solidarité nationale et de l'Équité territoriale"
-             )
-      )
-  )
+  router_ui(router)
 )
 
-# Server
+#---- Server ----
 server <- function(input, output, session) {
+  router_server(router)
+
+  data <- read_excel("data/Base0.xlsx")
+
   images <- c("piste.png", "electrification.png", "poste_sante.png", "real.png")
-  
-  output$carousel <- renderSlickR({
-    slickR(images, slideId = 'car1') +
-      settings(
-        autoplay = TRUE,
-        autoplaySpeed = 2500,
-        arrows = TRUE,
-        dots = TRUE,
-        infinite = TRUE
-      )
+
+  if (requireNamespace("slickR", quietly = TRUE)) {
+    output$carousel <- renderSlickR({
+      slickR::slickR(images, slideId = 'car1') +
+        slickR::settings(
+          autoplay = TRUE,
+          autoplaySpeed = 2500,
+          arrows = TRUE,
+          dots = TRUE,
+          infinite = TRUE
+        )
+    })
+  } else {
+    output$carousel <- renderUI({
+      div(lapply(images, function(img) tags$img(src = img, width = '100%')))
+    })
+  }
+
+  output$budgetPlot <- renderPlot({
+    df <- data %>% group_by(Source) %>% summarise(Budget = sum(as.numeric(Budget_FCFA), na.rm = TRUE))
+    ggplot(df, aes(x = reorder(Source, Budget), y = Budget, fill = Source)) +
+      geom_col(show.legend = FALSE) +
+      coord_flip() +
+      theme_minimal() +
+      labs(x = '', y = 'Budget (FCFA)')
+  })
+
+  output$budgetTable <- renderTable({
+    data
+  })
+
+  output$composantePlot <- renderPlot({
+    df <- data %>% group_by(Composante) %>% summarise(Budget = sum(as.numeric(Budget_FCFA), na.rm = TRUE))
+    ggplot(df, aes(x = reorder(Composante, Budget), y = Budget, fill = Composante)) +
+      geom_col(show.legend = FALSE) +
+      coord_flip() +
+      theme_minimal() +
+      labs(x = '', y = 'Budget (FCFA)')
   })
 }
 


### PR DESCRIPTION
## Summary
- refactor Shiny app into multiple pages using `shiny.router`
- add custom navigation bar with links to each page
- load `Base0.xlsx` once and provide example visualisations
- update README for new navigation instructions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6873b1e6bd90832580bf1410332dab64